### PR TITLE
Add "apmanual" Flag to Manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,19 +1,18 @@
-
 {
-    "name": "Pokémon Platinum Tracker V4",
-    "game_name": "Pokémon Platinum",
-    "package_version": "0.1.0",
-	"min_poptracker_version": "0.27.0",
-    "package_uid": "manual_pokemonplatinum_linneus_ap",
-    "author": "ZobeePlays (Sophie), palex00, darkfire006, & cheerioschelsea",
-    "variants": {
-        "Map Tracker": {
-            "display_name": "Map Tracker",
-            "flags": ["ap"]
-        },
-        "Items Only": {
-            "display_name": "Items Only",
-            "flags": ["ap"]
-        }
-    }
+	"name": "Pokémon Platinum AP Manual Tracker",
+	"game_name": "Manual_PokemonPlatinum_Linneus",
+	"package_version": "0.1.2",
+	"min_poptracker_version": "0.27.1",
+	"package_uid": "manual_pokemonplatinum_linneus_ap",
+	"author": "ZobeePlays (Sophie), darkfire006, cheerioschelsea & palex00",
+	"variants": {
+		"Map Tracker": {
+			"display_name": "Map Tracker",
+			"flags": ["ap", "apmanual"]
+		},
+		"Items Only": {
+			"display_name": "Items Only",
+			"flags": ["ap", "apmanual"]
+		}
+	}
 }


### PR DESCRIPTION
Required for tracker to act as a Manual Client.
According to [PopTracker docs](https://github.com/black-sliver/PopTracker/blob/master/doc/PACKS.md), `game_name` is used as `game`, so it should match the apworld name.
Updated `min_poptracker_version` that supports `"apmanual"`.
Updated `package_version`.